### PR TITLE
同一文章削除の速度向上

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /__pycache__/
 /*.csv
 /files/*.csv
+/files/*/

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ python wakati.py ./csvfiles/filename.csv ./csvfiles/newfilename.csv
 ```
 python stopword.py ./csvfiles/newfilename.csv ./csvfiles/updatefilename.csv
 ```
-1. 類似文章を削除する
+1. 類似文章を削除する(50000は文書の分割数, 小さいと早いが重複を残し、大きいと遅いが重複がよく減る)
 ```
-python not_same_text.py ./csvfiles/updatefilename.csv ./csvfiles/cutfilename.csv
+python not_same_text.py ./csvfiles/updatefilename.csv ./csvfiles/cutfilename.csv 50000
 ```
 
 ### 指定したサイズでのファイル切り出し

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ python stopword.py ./csvfiles/newfilename.csv ./csvfiles/updatefilename.csv
 ```
 1. 類似文章を削除する
 ```
-python carving.py ./csvfiles/updatefilename.csv ./csvfiles/cutfilename.csv
+python not_same_text.py ./csvfiles/updatefilename.csv ./csvfiles/cutfilename.csv
 ```
 
 ### 指定したサイズでのファイル切り出し

--- a/not_same_text.py
+++ b/not_same_text.py
@@ -76,7 +76,7 @@ if __name__ == '__main__':
     text_all_list = create_text_list(sys.argv[1])
     origin_text_all_list = text_all_list[:]
 
-    match_list, cleansing_text_list = distributed_processing(text_all_list, 10000)
+    match_list, cleansing_text_list = distributed_processing(text_all_list, sys.argv[3])
     recovery_text_list = recovery_list(match_list, cleansing_text_list, origin_text_all_list)
 
     save_text(recovery_text_list)

--- a/not_same_text.py
+++ b/not_same_text.py
@@ -61,7 +61,7 @@ if __name__ == '__main__':
     origin_text_all_list = text_all_list[:]
 
     match_list, cleansing_text_list = delete_if_same(text_all_list)
-    cleansing_text_list = recovery_list(match_list, cleansing_text_list, origin_text_all_list)
+    recovery_text_list = recovery_list(match_list, cleansing_text_list, origin_text_all_list)
 
-    save_text(cleansing_text_list)
+    save_text(recovery_text_list)
 

--- a/not_same_text.py
+++ b/not_same_text.py
@@ -54,13 +54,29 @@ def recovery_list(match_list, cleansing_text_list, origin_text_all_list):
         cleansing_text_list.append(origin_text_all_list[recovery_number])
     return cleansing_text_list
 
+def distributed_processing(text_all_list, process_number):
+    SPLIT_NUMBER = process_number
+    START_INDEX = 0
+    END_INDEX = process_number
+    match_all_list = []
+    cleansing_text_all_list = []
+    while True:
+        if len(text_all_list[START_INDEX:END_INDEX]) == 0:
+            break
+        print(END_INDEX, '/', len(text_all_list))
+        match_list, cleansing_text_list = delete_if_same(text_all_list[START_INDEX:END_INDEX])
+        match_all_list += match_list
+        cleansing_text_all_list += cleansing_text_list
+        START_INDEX += SPLIT_NUMBER
+        END_INDEX += SPLIT_NUMBER
+    return match_all_list, cleansing_text_all_list
 
 if __name__ == '__main__':
     calculation = calc.Calc()
     text_all_list = create_text_list(sys.argv[1])
     origin_text_all_list = text_all_list[:]
 
-    match_list, cleansing_text_list = delete_if_same(text_all_list)
+    match_list, cleansing_text_list = distributed_processing(text_all_list, 10000)
     recovery_text_list = recovery_list(match_list, cleansing_text_list, origin_text_all_list)
 
     save_text(recovery_text_list)

--- a/not_same_text.py
+++ b/not_same_text.py
@@ -4,7 +4,6 @@
 
 import calc
 import pandas as pd
-from time import time
 import sys
 
 def create_text_list(filename):
@@ -57,22 +56,12 @@ def recovery_list(match_list, cleansing_text_list, origin_text_all_list):
 
 
 if __name__ == '__main__':
-    start = time()
-
     calculation = calc.Calc()
     text_all_list = create_text_list(sys.argv[1])
     origin_text_all_list = text_all_list[:]
 
-    print("経過時間：", round(time() - start, 1), "秒です")
-
     match_list, cleansing_text_list = delete_if_same(text_all_list)
     cleansing_text_list = recovery_list(match_list, cleansing_text_list, origin_text_all_list)
 
-    print("経過時間：", round(time() - start, 1), "秒です")
-
     save_text(cleansing_text_list)
-
-
-
-
 

--- a/not_same_text.py
+++ b/not_same_text.py
@@ -25,11 +25,12 @@ def save_text(text_list):
     f.close()
 
 def delete_if_same(text_list):
+    from tqdm import tqdm
     match_list = []
     origin_text_all_list = text_list[:]
     pop_count = 0
-    for index, text in enumerate(origin_text_all_list):
-        print(round((index/len(origin_text_all_list)), 3)*100, "%")
+    print('[check same text]')
+    for index, text in enumerate(tqdm(origin_text_all_list)):
         dummy_text_all_list = origin_text_all_list[:]
         dummy_text_all_list.pop(index)
         if text in dummy_text_all_list:

--- a/stopword.py
+++ b/stopword.py
@@ -6,6 +6,7 @@
 import urllib.request
 import pandas as pd
 import sys
+from tqdm import tqdm
 
 f = urllib.request.urlopen('http://svn.sourceforge.jp/svnroot/slothlib/CSharp/Version1/SlothLib/NLP/Filter/StopWord/word/Japanese.txt')
 sw = [line.decode('utf-8').strip() for line in f] # 読み込んだurlから文章を読み込み
@@ -17,6 +18,8 @@ wakatiList = [w.strip() for w in wakati[0]]
 wakatiList = [ww for ww in wakatiList if not ww==u'']
 
 pdsw = [];
+print('[delete stopword]')
+wakatiList = tqdm(wakatiList)
 for w in wakatiList:
     stopRemove = []
     words = w.split()
@@ -27,6 +30,8 @@ for w in wakatiList:
     pdsw.append(stopRemove)
 
 f = open(sys.argv[2], 'w')
+print('[save text]')
+pdsw = tqdm(pdsw)
 for x in pdsw:
     f.write(str(x) + "\n")
 f.close()

--- a/wakati.py
+++ b/wakati.py
@@ -8,19 +8,21 @@
 
 import sys
 from parse import parser_space
+from tqdm import tqdm
 
 def wakati():
     fi = open(sys.argv[1], 'r')
     fo = open(sys.argv[2], 'w')
 
-    line = fi.readline()
-    while line:
+    text_data = fi.read()
+    fi.close()
+    lines = text_data.split('\n')
+    print('[wakati text & save text]')
+    for line in tqdm(lines):
         result = parser_space(line)
         result += "\n"
         fo.write(result[0:])
-        line = fi.readline()
 
-    fi.close()
     fo.close()
 
 if __name__ == '__main__':


### PR DESCRIPTION
### 概要
not_same_text.pyに渡す文章が多ければ多いほどに処理速度が落ちてしまう(pythonでは御法度のfor文をガンガンに回しているため)

読み込んだテキストを10万件ぐらいずつ処理を回し、処理後の文章を繋げるという作業を繰り返すことで1回分の処理を減らすことで速度向上を目指す